### PR TITLE
GCP waiter script implementation

### DIFF
--- a/aws/README.md.tmpl
+++ b/aws/README.md.tmpl
@@ -158,7 +158,7 @@ Also a role generated for allowing Lambda execution that validates the parameter
         "Statement": [{
             "Effect": "Allow",
             "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-            "Resource": "arn:aws:logs:*:*:*"
+            "Resource": "arn:aws:logs:eu-central-1:000000000000:*"
           }
         ]
       }

--- a/aws/cbd-advanced.tmpl
+++ b/aws/cbd-advanced.tmpl
@@ -291,7 +291,7 @@
             "Statement": [{
                 "Effect": "Allow",
                 "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-                "Resource": "arn:aws:logs:*:*:*"
+                "Resource": { "Fn::Join" : ["", [ "arn:aws:logs:", { "Ref" : "AWS::Region" }, ":", { "Ref" : "AWS::AccountId" } , ":*", ""]] }
               }
             ]
           }

--- a/gcp/README.md.tmpl
+++ b/gcp/README.md.tmpl
@@ -3,9 +3,14 @@ We use [Google deployment manager](https://cloud.google.com/deployment-manager/d
 The only dependency that needs to be installed on your machine is the [Google cloud SDK](https://cloud.google.com/sdk/downloads). The SDK contains the [gcloud CLI tool](https://cloud.google.com/sdk/gcloud/) which is the main pillar of our deployer examples.
 The virtual machines always started from the latest Centos 7 image that is available under the centos-cloud image repository.
 
-## Deploy {{$VERSION}} via gcloud command line interface by using template config
-#### Please review and customize the following fields of vm_template_config.yaml file first
+## Prerequisites
+ * [Google cloud SDK](https://cloud.google.com/sdk/downloads)
+ * The `Compute Engine API` and the `Cloud Runtime Configuration API` services need to be enabled under the navigation menu `APIs & Services` subitem. Click on "ENABLE APIS AND SERVICES" then type the service names in the filter and enable it.
+ * A service account is needed that has read and write permissions to `Compute Image`, `Compute Instance`, `Compute Network`, `Compute Security` and `Cloud RuntimeConfig`. This service account email needs to specified in the config.yaml or in the gcloud command explicitly as a property.
 
+## Deploy {{$VERSION}} via gcloud command line interface by using template config
+
+#### Please review and customize the following fields of vm_template_config.yaml file first
 ```yaml
     region: us-central1
     zone: us-central1-a
@@ -14,6 +19,7 @@ The virtual machines always started from the latest Centos 7 image that is avail
     os_user: cloudbreak
     user_email: admin@example.com
     user_password: cloudbreak
+    service_account_email: ...
 ```
 
 #### Run the following command to create a new deployment
@@ -34,7 +40,7 @@ With the `gcloud` command-line tool, you can pass in the template file directly 
 ```
 gcloud deployment-manager deployments create cbd-deployment \
     --template=vm-template.jinja \
-    --properties region:us-central1,zone:us-central1-a,instance_type:n1-standard-4,os_user:cloudbreak,user_email:admin@example.com,user_password:'cloudbreak',cbd_version:{{$VERSION}},startup-script:'https://raw.githubusercontent.com/hortonworks/cbd-quickstart/{{$VERSION}}/install-and-start-cbd.sh',ssh_pub_key:'....'
+    --properties region:us-central1,zone:us-central1-a,instance_type:n1-standard-4,os_user:cloudbreak,user_email:admin@example.com,user_password:'cloudbreak',cbd_version:{{$VERSION}},startup-script:'https://raw.githubusercontent.com/hortonworks/cbd-quickstart/{{$VERSION}}/install-and-start-cbd.sh',ssh_pub_key:'....',service_account_email:'..'
 ```
 
 # Image versions of the templates

--- a/gcp/vm-template.jinja
+++ b/gcp/vm-template.jinja
@@ -1,3 +1,7 @@
+{% set configName = env["deployment"] + "-startup-config" %}
+{% set waiterName = env["deployment"] + "-startup-waiter" %}
+{% set instanceName = env["deployment"] + "-vm" %}
+
 resources:
 - type: compute.v1.network
   name: {{ env["deployment"] }}-network
@@ -36,7 +40,7 @@ resources:
     - IPProtocol: tcp
       ports: [ "22", "80", "443" ]
 - type: compute.v1.instance
-  name: vm-{{ env["deployment"] }}
+  name: {{ instanceName }}
   properties:
     zone: {{ properties["zone"] }}
     machineType: https://www.googleapis.com/compute/v1/projects/{{ env['project'] }}/zones/{{ properties["zone"] }}/machineTypes/{{ properties["instance_type"] }}
@@ -61,6 +65,7 @@ resources:
       - key: startup-script
         value: |
           #! /bin/bash
+          export GCP_RUNTIME_CONFIG_NAME={{ configName }}
           echo "export CBD_VERSION={{ properties["cbd_version"] }}" >> /tmp/.cbdprofile
           echo "export OS_USER='{{ properties["os_user"] }}'" >> /tmp/.cbdprofile
           echo "export UAA_DEFAULT_USER_EMAIL='{{ properties["user_email"] }}'" >> /tmp/.cbdprofile
@@ -73,3 +78,36 @@ resources:
       - key: ssh-keys
         value: |-
           {{ properties["os_user"] }}: {{ properties["ssh_pub_key"] }}
+    serviceAccounts:
+    - email: {{ properties["service_account_email"] }}
+      scopes:
+      - 'https://www.googleapis.com/auth/cloudruntimeconfig'
+
+
+- type: runtimeconfig.v1beta1.config
+  name: {{ configName }}
+  properties:
+    config: {{ configName }}
+
+- type: runtimeconfig.v1beta1.waiter
+  name: {{ waiterName }}
+  metadata:
+    dependsOn:
+    - {{ instanceName }}
+
+  properties:
+    parent: $(ref.{{ configName }}.name)
+    waiter: {{ waiterName }}
+    timeout: 900s  # 15 minutes
+    success:
+      cardinality:
+        path: /success
+        number: 1
+    failure:
+      cardinality:
+        path: /failure
+        number: 1
+
+outputs:
+- name: deploymentIp
+  value: $(ref.{{ instanceName }}.networkInterfaces[0].accessConfigs[0].natIP)

--- a/gcp/vm_template_config.tmpl
+++ b/gcp/vm_template_config.tmpl
@@ -2,7 +2,7 @@ imports:
 - path: vm-template.jinja
 
 resources:
-- name: my-vm
+- name: deployment-vm
   type: vm-template.jinja
   properties:
     cbd_version: {{ $VERSION }}
@@ -15,3 +15,8 @@ resources:
     os_user: cloudbreak
     user_email: admin@example.com
     user_password: cloudbreak
+    service_account_email: ...
+
+outputs:
+- name: deploymentIp
+  value: $(ref.deployment-vm.deploymentIp)


### PR DESCRIPTION
**Changes:**
 - GCP waiter script implementation that provides that the deployment will be green on the UI and CLI only when the startup script that install and start Cloudbreak has been finished successfully. @dbialek2 this change required more prerequisites from the GCP side that has been added to the template of the Markdown file `gcp/README.md.tmpl`
 - Lambda execution role with less open permission
 - GCP external IP as output of the deployer command